### PR TITLE
fix: charts

### DIFF
--- a/apps/api/src/coding-data/coding-data.service.ts
+++ b/apps/api/src/coding-data/coding-data.service.ts
@@ -1,6 +1,5 @@
 import { CodingDataDtoType } from "./coding-data.dto";
 import { DailyDataService } from "src/daily-data/daily-data.service";
-import { Date } from "src/types";
 import { Injectable } from "@nestjs/common";
 import { LanguagesService } from "src/languages/languages.service";
 import findDailyDataForWeek from "src/utils/findDailyDataForWeek";
@@ -76,6 +75,7 @@ export class CodingDataService {
 
     return dailyDataForWeek.map(({ timeSpent, date }) => ({
       timeSpentLine: timeSpent,
+      originalDate: new Date(date).toDateString(),
       date: new Date(date).toLocaleDateString("en-US", { weekday: "long" }),
       timeSpentBar: timeSpent,
       value: formatDuration(timeSpent),
@@ -111,14 +111,16 @@ export class CodingDataService {
       return acc;
     }, {});
 
-    const finalData = Object.entries(kVLangTime).map(
-      ([languageName, timeSpent]) => ({
+    const finalData = Object.entries(kVLangTime)
+      .map(([languageName, timeSpent]) => ({
         languageName,
         time: timeSpent,
         value: formatDuration(timeSpent),
-        percentage: ((timeSpent * 100) / totalTimeSpentInTheWeek).toFixed(2),
-      }),
-    );
+        percentage: parseFloat(
+          ((timeSpent * 100) / totalTimeSpentInTheWeek).toFixed(2),
+        ),
+      }))
+      .sort((a, b) => a.time - b.time);
 
     return finalData;
   }
@@ -136,7 +138,7 @@ export class CodingDataService {
     );
     return await Promise.all(
       dailyDataForWeek.map(async ({ id, date, timeSpent }) => ({
-        originalDate: date,
+        originalDate: new Date(date).toDateString(),
 
         date: new Date(date).toLocaleDateString("en-US", { weekday: "long" }),
         timeSpent,

--- a/apps/api/src/languages/languages.service.ts
+++ b/apps/api/src/languages/languages.service.ts
@@ -1,6 +1,6 @@
 import { CreateLanguageDtoType, UpdateLanguageDtoType } from "./languages.dto";
 import { Inject, Injectable } from "@nestjs/common";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { DrizzleAsyncProvider } from "src/drizzle/drizzle.provider";
 import { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { languages } from "src/drizzle/schema/languages";
@@ -34,7 +34,8 @@ export class LanguagesService {
         languageName: languages.languageName,
       })
       .from(languages)
-      .where(eq(languages.dailyDataId, dailyDataId));
+      .where(eq(languages.dailyDataId, dailyDataId))
+      .orderBy(asc(languages.timeSpent));
 
     const languagesDataObject = Object.fromEntries(
       languagesDataArray.map(({ languageName, timeSpent }) => [

--- a/apps/dashboard/src/colors.json
+++ b/apps/dashboard/src/colors.json
@@ -474,7 +474,7 @@
   "overpassql": { "name": "OverpassQL", "color": "#cce2aa" },
   "ox": { "name": "Ox", "color": null },
   "oxygene": { "name": "Oxygene", "color": "#cdd0e3" },
-  "other": { "name": "Others", "color": "#ffdc67" },
+  "other": { "name": "Others", "color": "#f31273" },
   "oz": { "name": "Oz", "color": "#fab738" },
   "p4": { "name": "P4", "color": "#7055b5" },
   "pact": { "name": "Pact", "color": "#F7A8B8" },

--- a/apps/dashboard/src/components/dashboard-page/TimeSpentOnPeriod.tsx
+++ b/apps/dashboard/src/components/dashboard-page/TimeSpentOnPeriod.tsx
@@ -2,6 +2,7 @@ import { Period } from "@/types-schemas";
 import PeriodDropDown from "./PeriodDropDown";
 import { Skeleton } from "../ui/skeleton";
 import { cn } from "@/lib/utils";
+import { offsets } from "@/constants";
 import { trpc } from "@/utils/trpc";
 import { useState } from "react";
 
@@ -14,7 +15,7 @@ const TimeSpentOnPeriod = () => {
   const { isLoading, error, data } =
     trpc.codingData.getTimeSpentOnWeek.useQuery(
       {
-        offset: 1,
+        offset: offsets[period],
       },
       { refetchOnWindowFocus: true },
     );

--- a/apps/dashboard/src/components/dashboard-page/charts/WeekLanguagesChart.tsx
+++ b/apps/dashboard/src/components/dashboard-page/charts/WeekLanguagesChart.tsx
@@ -58,92 +58,99 @@ const WeekLanguagesChart = () => {
         className="absolute -top-12 right-0 z-0"
         onClick={handleClick}
       />
-      <ChartContainer config={chartConfig} className="min-h-96 w-full">
-        {isPieChartVisible ? (
-          <PieChart accessibilityLayer>
-            <ChartTooltip
-              labelFormatter={() => <div className="font-semibold">Time</div>}
-              content={<ChartTooltipContent labelClassName="font-semibold" />}
-              formatter={(value: string, language, { payload }) =>
-                CustomChartToolTip(
-                  parseInt(value),
-                  payload.color,
-                  language.toString(),
-                  payload.percentage,
+      <div className="flex min-h-96 flex-col rounded-md border border-neutral-600/50">
+        <h2 className="text-center text-2xl font-bold">Languages</h2>
+        <ChartContainer
+          config={chartConfig}
+          className="w-full flex-1 border-none"
+        >
+          {isPieChartVisible ? (
+            <PieChart accessibilityLayer>
+              <ChartTooltip
+                labelFormatter={() => <div className="font-semibold">Time</div>}
+                content={<ChartTooltipContent labelClassName="font-semibold" />}
+                formatter={(value: string, language, { payload }) =>
+                  CustomChartToolTip(
+                    parseInt(value),
+                    payload.color,
+                    language.toString(),
+                    payload.percentage,
+                  )
+                }
+              />
+              <ChartLegend
+                content={
+                  <ChartLegendContent order="DESC" className="text-xs" />
+                }
+                className="flex-wrap justify-end pr-2 max-small:hidden"
+                layout="vertical"
+                verticalAlign="middle"
+                align="right"
+              />
+              <Pie
+                data={pieChartData}
+                dataKey="time"
+                nameKey="languageName"
+                className="cursor-pointer"
+              >
+                {pieChartData?.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.color} />
+                ))}
+              </Pie>
+            </PieChart>
+          ) : (
+            <BarChart accessibilityLayer data={barChartData}>
+              <CartesianGrid vertical={false} horizontal={false} />
+              <XAxis
+                dataKey="date"
+                tickLine={false}
+                tickMargin={10}
+                axisLine={false}
+                tickFormatter={(value) => value.slice(0, 3)}
+              />
+
+              <ChartTooltip
+                content={<ChartTooltipContent labelClassName="font-semibold" />}
+                labelFormatter={(
+                  _date: string,
+                  payload: Payload<string, string>[],
+                ) => <div>{payload[0].payload.originalDate}</div>}
+                formatter={(value: string, language) =>
+                  CustomChartToolTip(
+                    parseInt(value),
+                    languagesAttributes[
+                      language as keyof typeof languagesAttributes
+                    ].color || DEFAULT_COLOR,
+                    language,
+                  )
+                }
+              />
+              {[...new Set(barChartData?.flatMap((day) => Object.keys(day)))]
+                .filter(
+                  (key) =>
+                    key !== "date" &&
+                    key !== "timeSpent" &&
+                    key !== "originalDate",
                 )
-              }
-            />
-            <ChartLegend
-              content={<ChartLegendContent order="DESC" className="text-xs" />}
-              className="flex-wrap justify-end max-small:hidden"
-              layout="vertical"
-              verticalAlign="middle"
-              align="right"
-            />
-            <Pie
-              data={pieChartData}
-              dataKey="time"
-              nameKey="languageName"
-              className="cursor-pointer"
-            >
-              {pieChartData?.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={entry.color} />
-              ))}
-            </Pie>
-          </PieChart>
-        ) : (
-          <BarChart accessibilityLayer data={barChartData}>
-            <CartesianGrid vertical={false} horizontal={false} />
-            <XAxis
-              dataKey="date"
-              tickLine={false}
-              tickMargin={10}
-              axisLine={false}
-              tickFormatter={(value) => value.slice(0, 3)}
-            />
-            <ChartTooltip
-              content={<ChartTooltipContent labelClassName="font-semibold" />}
-              labelFormatter={(
-                date: string,
-                payload: Payload<string, string>[],
-              ) => (
-                <div>{`${date.slice(0, 3)} ${payload[0].payload.originalDate}`}</div>
-              )}
-              formatter={(value: string, language) =>
-                CustomChartToolTip(
-                  parseInt(value),
-                  languagesAttributes[
-                    language as keyof typeof languagesAttributes
-                  ].color || DEFAULT_COLOR,
-                  language,
-                )
-              }
-            />
-            {[...new Set(barChartData?.flatMap((day) => Object.keys(day)))]
-              .filter(
-                (key) =>
-                  key !== "date" &&
-                  key !== "timeSpent" &&
-                  key !== "originalDate",
-              )
-              .map((language) => {
-                return (
-                  <Bar
-                    key={language}
-                    dataKey={language}
-                    stackId="a"
-                    fill={
-                      (languagesAttributes[
-                        language as keyof typeof languagesAttributes
-                      ].color as string) || DEFAULT_COLOR
-                    }
-                    className="cursor-pointer"
-                  />
-                );
-              })}
-          </BarChart>
-        )}
-      </ChartContainer>
+                .map((language) => {
+                  return (
+                    <Bar
+                      key={language}
+                      dataKey={language}
+                      stackId="a"
+                      fill={
+                        (languagesAttributes[
+                          language as keyof typeof languagesAttributes
+                        ].color as string) || DEFAULT_COLOR
+                      }
+                      className="cursor-pointer"
+                    />
+                  );
+                })}
+            </BarChart>
+          )}
+        </ChartContainer>
+      </div>
     </div>
   );
 };

--- a/apps/dashboard/src/components/dashboard-page/charts/WeekTimeChart.tsx
+++ b/apps/dashboard/src/components/dashboard-page/charts/WeekTimeChart.tsx
@@ -4,10 +4,11 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { WeeklyPeriod, offsets } from "@/types-schemas";
+import { chartConfig, offsets } from "@/constants";
 import CustomChartToolTip from "../../ui/custom-chart-tool-tip";
+import { Payload } from "recharts/types/component/DefaultTooltipContent";
 import { Skeleton } from "@/components/ui/skeleton";
-import { chartConfig } from "@/constants";
+import { WeeklyPeriod } from "@/types-schemas";
 import { trpc } from "@/utils/trpc";
 import { useState } from "react";
 
@@ -52,6 +53,10 @@ const WeekTimeChart = () => {
         />
         <ChartTooltip
           content={<ChartTooltipContent labelClassName="font-semibold" />}
+          labelFormatter={(
+            _date: string,
+            payload: Payload<string, string>[],
+          ) => <div>{payload[0].payload.originalDate}</div>}
           formatter={(value: string, name) =>
             name === "Time"
               ? CustomChartToolTip(parseInt(value), "var(--color-time)")

--- a/apps/dashboard/src/constants.ts
+++ b/apps/dashboard/src/constants.ts
@@ -32,4 +32,15 @@ export const chartConfig = {
   },
 } satisfies ChartConfig;
 
-export const DEFAULT_COLOR = "HSL(46, 100%, 30%)";
+export const DEFAULT_COLOR = "HSL(334, 90%, 51%)";
+
+export const offsets = {
+  "Past week": 1,
+  Today: 0,
+  Yesterday: 1,
+  "Last 3 days": 3,
+  "This week": 0,
+  "Past 2 weeks": 2,
+  "This month": 0,
+  "Previous month": 1,
+} as const;

--- a/apps/dashboard/src/types-schemas.ts
+++ b/apps/dashboard/src/types-schemas.ts
@@ -9,14 +9,3 @@ export type Period =
   | "This month";
 
 export type WeeklyPeriod = Extract<Period, "Past week" | "This week">;
-
-export const offsets = {
-  "Past week": 1,
-  Today: 0,
-  Yesterday: 1,
-  "Last 3 days": 3,
-  "This week": 0,
-  "Past 2 weeks": 2,
-  "This month": 0,
-  "Previous month": 1,
-} as const;


### PR DESCRIPTION
- refactored the getDaysOfWeekStats to return the "originalData" property as a DateString
- made the getWeekLanguagesTime return the same array as before but sorted
- updated the WeekTimeChart to only use the originalDate as label for the tooltip
- added a title for the WeekLanguagesChart and there also got the originalDate as a DateString
- replaced the hard-coded value 0 in the query in TimeSpentOnPeriod by offsets[period] -moved the offsets object from types-schemas.ts to constants.ts
- changed the color of "other" in colors.json