### PR TITLE
chore: api deployment

### DIFF
--- a/apps/dashboard/.gitignore
+++ b/apps/dashboard/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env*
 
 # Editor directories and files
 .vscode

--- a/apps/dashboard/src/components/login-page/LoginForm.tsx
+++ b/apps/dashboard/src/components/login-page/LoginForm.tsx
@@ -8,7 +8,6 @@ import {
 } from "../ui/form";
 import {
   INCORRECT_PASSWORD_MESSAGE,
-  LOGIN_URL,
   USER_NOT_FOUND_MESSAGE,
 } from "@repo/utils/constants";
 import { Link, useNavigate } from "react-router";
@@ -45,6 +44,7 @@ const LoginForm = () => {
   const onSubmit = async (values: SignInUserDtoType) => {
     try {
       // send the credentials to the backend and set an http cookie in the browser
+      const LOGIN_URL = import.meta.env.VITE_LOGIN_URL;
 
       const token = await fetchJWTToken(LOGIN_URL, {
         email: values.email,

--- a/apps/dashboard/src/components/register-page/RegisterForm.tsx
+++ b/apps/dashboard/src/components/register-page/RegisterForm.tsx
@@ -1,7 +1,6 @@
 import {
   ALREADY_EXISTING_EMAIL_MESSAGE,
   ALREADY_EXISTING_USERNAME_MESSAGE,
-  REGISTER_URL,
 } from "@repo/utils/constants";
 import {
   Form,
@@ -45,6 +44,8 @@ const RegisterForm = () => {
 
   const onSubmit = async (values: RegisterUserDtoType) => {
     try {
+      const REGISTER_URL = import.meta.env.VITE_REGISTER_URL;
+
       const token = await fetchJWTToken(REGISTER_URL, {
         email: values.email,
         username: values.username,

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
+  readonly VITE_LOGIN_URL: string;
+  readonly VITE_REGISTER_URL: string;
 }
 
 interface ImportMeta {

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -1,5 +1,7 @@
 import { FileMap, LanguageMap } from "./types-schemas";
 
+export const API_URL = "https://mooncode-api.fly.dev/trpc";
+
 export const MAX_IDLE_TIME = 600; //seconds
 
 export const languageMapping: Record<string, string> = {

--- a/apps/vscode-extension/src/utils/trpc/client.ts
+++ b/apps/vscode-extension/src/utils/trpc/client.ts
@@ -1,5 +1,5 @@
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
-import { API_URL } from "@repo/utils/constants";
+import { API_URL } from "../../constants";
 import type { AppRouter } from "@repo/trpc/router";
 import getToken from "../auth/getToken";
 import superjson from "superjson";

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,17 @@
+app = "mooncode-api"
+primary_region = "cdg"
+
+[build]
+  dockerfile = "apps/api/Dockerfile"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 512

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
-        "husky": "^9.1.7",
         "lint-staged": "^15.5.1",
         "prettier": "^3.5.0",
         "turbo": "^2.5.4",
@@ -11985,22 +11984,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/packages/trpc/src/router.ts
+++ b/packages/trpc/src/router.ts
@@ -1,1 +1,1 @@
-export type { AppRouter } from "../../../apps/api/dist/trpc/trpc.router";
+export type { AppRouter } from "../../../apps/api/src/trpc/trpc.router";

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -8,7 +8,5 @@ export const COOKIE_OR_TOKEN_NOT_FOUND_MESSAGE = "Auth cookie/token missing";
 
 // TODO store the three first of them in a .env
 export const API_URL = "http://localhost:3000/trpc";
-export const LOGIN_URL = "http://localhost:3000/trpc/auth.signInUser";
-export const REGISTER_URL = "http://localhost:3000/trpc/auth.registerUser";
 export const DASHBOARD_PORT = 4208;
 export const DASHBOARD_URL = `http://localhost:${DASHBOARD_PORT}`;

--- a/packages/utils/src/fetchJWTToken.ts
+++ b/packages/utils/src/fetchJWTToken.ts
@@ -1,8 +1,8 @@
-import { AuthEndPointURL, TrpcAuthError } from "./types";
+import { TrpcAuthError } from "./types";
 import { loginResponseSchema } from "./schemas";
 
 const fetchJWTToken = async (
-  endpointURL: AuthEndPointURL,
+  endpointURL: string,
   body: {
     email: string;
     password: string;
@@ -11,7 +11,6 @@ const fetchJWTToken = async (
   },
 ) => {
   const { email, password, username, callbackUrl } = body;
-  console.log(callbackUrl);
   const res = await fetch(endpointURL, {
     method: "POST",
     headers: {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,5 +1,4 @@
 import { JWTDto, RegisterUserDto, SignInUserDto } from "./schemas";
-import { LOGIN_URL, REGISTER_URL } from "./constants";
 import z from "zod";
 
 export const GroupByEnum = ["days", "weeks", "months"] as const;
@@ -18,6 +17,3 @@ export type TrpcAuthError = {
     };
   };
 };
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const tuple = [REGISTER_URL, LOGIN_URL] as const;
-export type AuthEndPointURL = (typeof tuple)[number];


### PR DESCRIPTION
## Commits
- [chore: api deployment](https://github.com/Friedrich482/mooncode-monorepo/commit/489f55c81faa1e68694663afedcd6be56089aa0a)

	- added a fly.toml file to deploy the api to [fly.io](https://fly.io)
	- added all .env files to the gitignore in the dashboard
	- added new environment variables to the `vite-env.d.ts` : `VITE_LOGIN_URL` and `VITE_REGISTER_URL`
	- updated the LoginForm and RegisterForm component to use the environment variables defined. In development, it uses localhost and in prod, [fly.io](https://fly.io)
	- redefined the API_URL in the extension to point to the prod deployment on [fly.io](https://fly.io)
	- updated the router.ts path to the AppRouter type
	- removed the LOGIN_URL and REGISTER_URL from the constants since they are defined as environment variables in the dashboard
	- loosened the type of the parameter endpointURL to string in the fetchJWTToken
	- removed the AuthEndpointURL type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable handling for login and registration URLs in the dashboard app.
  * Extended type definitions to support new environment variables.
  * Updated `.gitignore` to exclude environment files in the dashboard app.
  * Added deployment configuration for the API service.

* **New Features**
  * Introduced a new API URL constant for the VS Code extension.

* **Refactor**
  * Adjusted import paths and removed unused constants and types for cleaner code structure.
  * Simplified function signatures and removed unnecessary logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->