### PR TITLE
Revert: login/logout, fix: returning data and fix: fileName 

### DIFF
--- a/apps/api/compose.yaml
+++ b/apps/api/compose.yaml
@@ -7,9 +7,9 @@ services:
     volumes:
       - mooncode_postgres:/var/lib/postgresql/data
     environment:
-      - POSTGRES_PASSWORD: postgres
-      - POSTGRES_USER: postgres
-      - POSTGRES_DB: mooncode
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=mooncode
 volumes:
   mooncode_postgres:
     name: mooncode_postgres_db

--- a/apps/api/src/coding-stats/coding-stats-extension.service.ts
+++ b/apps/api/src/coding-stats/coding-stats-extension.service.ts
@@ -106,6 +106,9 @@ export class CodingStatsExtensionService {
             });
           returningData.languages[updatedLanguageData.languageSlug] =
             updatedLanguageData.timeSpent;
+        } else {
+          returningData.languages[existingLanguageData.languageSlug] =
+            existingLanguageData.timeSpent;
         }
       }
     }

--- a/apps/api/src/files-stats/files-stats-extension.service.ts
+++ b/apps/api/src/files-stats/files-stats-extension.service.ts
@@ -60,25 +60,15 @@ export class FilesStatsExtensionService {
       return {};
     }
 
-    const returningData: {
-      [path: string]: {
-        languageSlug: string;
-        projectName: string;
-        projectPath: string;
-        timeSpent: number;
-      };
-    } = Object.fromEntries(
+    const returningData = Object.fromEntries(
       Object.entries(
         await this.filesService.findAllFilesOnDay({
           dailyDataId: dailyDataForDay.id,
         }),
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      ).map(([filePath, { fileName, ...rest }]) => [filePath, rest]),
+      ),
     );
 
     for (const [path, file] of Object.entries(filesData)) {
-      const fileName = path.split("/").pop()!;
-
       const existingProject = await this.projectsService.findOneProject({
         dailyDataId: dailyDataForDay.id,
         name: file.projectName,
@@ -130,7 +120,7 @@ export class FilesStatsExtensionService {
 
       const existingFileData = await this.filesService.findOneFile({
         projectId: returningProjectData.projectId,
-        name: fileName,
+        name: file.fileName,
         path,
         languageId: fileLanguage.languageId,
       });
@@ -140,7 +130,7 @@ export class FilesStatsExtensionService {
         await this.filesService.createFile({
           projectId: returningProjectData.projectId,
           languageId: fileLanguage.languageId,
-          name: fileName,
+          name: file.fileName,
           path,
           timeSpent: file.timeSpent,
         });
@@ -150,6 +140,7 @@ export class FilesStatsExtensionService {
           projectName: file.projectName,
           projectPath: file.projectPath,
           timeSpent: file.timeSpent,
+          fileName: file.fileName,
         };
       } else {
         // else just update the file data but only if the new timeSpent is greater than the existing one
@@ -159,7 +150,7 @@ export class FilesStatsExtensionService {
             languageId: fileLanguage.languageId,
             path,
             timeSpent: file.timeSpent,
-            name: fileName,
+            name: file.fileName,
           });
 
           returningData[path] = {
@@ -167,12 +158,14 @@ export class FilesStatsExtensionService {
             projectName: file.projectName,
             projectPath: file.projectPath,
             timeSpent: file.timeSpent,
+            fileName: file.fileName,
           };
         } else {
           returningData[path] = {
             languageSlug: file.languageSlug,
             projectName: file.projectName,
             projectPath: file.projectPath,
+            fileName: file.fileName,
             timeSpent: existingFileData.timeSpent,
           };
         }

--- a/apps/api/src/files-stats/files-stats.dto.ts
+++ b/apps/api/src/files-stats/files-stats.dto.ts
@@ -24,6 +24,7 @@ export const UpsertFilesDto = z.object({
       languageSlug: z.string().min(1),
       projectName: z.string().min(1),
       projectPath: z.string().min(1),
+      fileName: z.string().min(1),
     }),
   ),
   targetedDate: dateStringDto,

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -60,6 +60,10 @@
         "title": "MoonCode: Login"
       },
       {
+        "command": "MoonCode.logout",
+        "title": "MoonCode: Logout"
+      },
+      {
         "command": "MoonCode.openDashboard",
         "title": "MoonCode: Open Dashboard"
       }
@@ -69,6 +73,10 @@
         {
           "command": "MoonCode.login",
           "when": "!MoonCode.isLoggedIn"
+        },
+        {
+          "command": "MoonCode.logout",
+          "when": "MoonCode.isLoggedIn"
         }
       ]
     }

--- a/apps/vscode-extension/src/constants.ts
+++ b/apps/vscode-extension/src/constants.ts
@@ -1,8 +1,8 @@
 import { FileMap, LanguageMap } from "./types-schemas";
 
-export const API_URL = "https://mooncode-api.fly.dev/trpc";
+export const API_URL = "http://localhost:3000/trpc";
 
-export const MAX_IDLE_TIME = 120; //seconds
+export const MAX_IDLE_TIME = 300; //seconds
 
 export const languageMapping: Record<string, string> = {
   dockercompose: "docker",

--- a/apps/vscode-extension/src/types-schemas.ts
+++ b/apps/vscode-extension/src/types-schemas.ts
@@ -20,6 +20,7 @@ export type FileData = {
   projectName: string;
   projectPath: string;
   languageSlug: string;
+  fileName: string;
 };
 
 export const globalStateInitialDataSchema = z.object({
@@ -44,6 +45,7 @@ export const globalStateInitialDataSchema = z.object({
           projectPath: z.string().min(1),
           languageSlug: z.string().min(1),
           projectName: z.string().min(1),
+          fileName: z.string().min(1),
         }),
       ),
 

--- a/apps/vscode-extension/src/utils/auth/logout.ts
+++ b/apps/vscode-extension/src/utils/auth/logout.ts
@@ -1,0 +1,50 @@
+import * as vscode from "vscode";
+import { SYNC_DATA_KEY, filesData, languagesData } from "../../constants";
+import deleteToken from "./deleteToken";
+import { getExtensionContext } from "../../extension";
+import login from "./login";
+import setLoginContext from "./setLoginContext";
+
+const logout = async () => {
+  //!! add a warning to prevent the user that all local data will be lost
+  const context = getExtensionContext();
+
+  await deleteToken(context);
+
+  await setLoginContext(false);
+
+  //  purge the local data of the current user
+  Object.keys(languagesData).forEach((key) => {
+    delete languagesData[key];
+  });
+
+  Object.keys(filesData).forEach((key) => {
+    delete filesData[key];
+  });
+
+  const todaysDateString = new Date().toLocaleDateString();
+  await context.globalState.update(SYNC_DATA_KEY, {
+    lastServerSync: new Date(),
+    dailyData: {
+      [todaysDateString]: {
+        timeSpentOnDay: 0,
+        timeSpentPerLanguage: {},
+        dayFilesData: {},
+        updatedAt: new Date(),
+      },
+    },
+  });
+
+  const selection = await vscode.window.showInformationMessage(
+    "Logged out",
+    "Login",
+    "Cancel",
+  );
+
+  if (selection === "Login") {
+    await login();
+  } else {
+    return;
+  }
+};
+export default logout;

--- a/apps/vscode-extension/src/utils/files/getCurrentFileProperties.ts
+++ b/apps/vscode-extension/src/utils/files/getCurrentFileProperties.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
+
 const getCurrentFileProperties = (
   document: vscode.TextDocument | undefined,
 ) => {
@@ -8,6 +9,7 @@ const getCurrentFileProperties = (
       projectName: null,
       projectPath: null,
       absolutePath: null,
+      fileName: null,
     };
   }
 
@@ -21,13 +23,18 @@ const getCurrentFileProperties = (
       projectName: null,
       projectPath: null,
       absolutePath: null,
+      fileName: null,
     };
   }
+
+  const absolutePath = path.normalize(fileUri.fsPath);
+  const fileName = path.basename(absolutePath);
 
   return {
     projectName,
     projectPath,
-    absolutePath: path.normalize(fileUri.fsPath),
+    absolutePath,
+    fileName,
   };
 };
 

--- a/apps/vscode-extension/src/utils/files/initializeFiles.ts
+++ b/apps/vscode-extension/src/utils/files/initializeFiles.ts
@@ -17,6 +17,7 @@ const initializeFiles = (data: FileDataSync) => {
       projectName: file.projectName,
       projectPath: file.projectPath,
       languageSlug: file.languageSlug,
+      fileName: file.fileName,
     };
   });
 };

--- a/apps/vscode-extension/src/utils/files/updateCurrentFileObj.ts
+++ b/apps/vscode-extension/src/utils/files/updateCurrentFileObj.ts
@@ -4,11 +4,17 @@ import getCurrentFileProperties from "./getCurrentFileProperties";
 import getLanguageSlug from "../languages/getLanguageSlug";
 
 const updateCurrentFileObj = (document: vscode.TextDocument | undefined) => {
-  const { absolutePath, projectName, projectPath } =
+  const { absolutePath, projectName, projectPath, fileName } =
     getCurrentFileProperties(document);
   const currentLanguageSlug = getLanguageSlug(document);
 
-  if (!absolutePath || !projectName || !projectPath || !currentLanguageSlug) {
+  if (
+    !absolutePath ||
+    !projectName ||
+    !projectPath ||
+    !currentLanguageSlug ||
+    !fileName
+  ) {
     return;
   }
 
@@ -23,6 +29,7 @@ const updateCurrentFileObj = (document: vscode.TextDocument | undefined) => {
       projectName,
       projectPath,
       languageSlug: currentLanguageSlug,
+      fileName,
     };
   }
 

--- a/apps/vscode-extension/src/utils/initExtensionCommands.ts
+++ b/apps/vscode-extension/src/utils/initExtensionCommands.ts
@@ -4,6 +4,7 @@ import calculateTime from "./calculateTime";
 import { getExtensionContext } from "../extension";
 import getGlobalStateData from "./getGlobalStateData";
 import login from "./auth/login";
+import logout from "./auth/logout";
 import openDashboard from "./openDashboard";
 
 const initExtensionCommands = (
@@ -18,24 +19,21 @@ const initExtensionCommands = (
     "MoonCode.showCurrentLanguagesData",
     () => {
       const { languagesData } = getTime();
-      vscode.window.showInformationMessage(
-        `currentLanguagesData: ${JSON.stringify(Object.entries(languagesData).map(([key, { elapsedTime }]) => `${key}: ${elapsedTime} seconds`))}`,
-      );
+
+      const formattedData = Object.entries(languagesData)
+        .map(([key, { elapsedTime }]) => `${key}: ${elapsedTime} seconds`)
+        .join("\n");
+      console.log(`Current Languages Data:\n${formattedData}`);
     },
   );
 
   const showInitialLanguagesDataCommand = vscode.commands.registerCommand(
     "MoonCode.showInitialLanguagesData",
-    async () => {
-      const globalStateData = await getGlobalStateData();
-
-      vscode.window.showInformationMessage(
-        `initialLanguagesData from server: ${JSON.stringify(Object.entries(initialLanguagesData).map(([key, elapsedTime]) => `${key}: ${elapsedTime} seconds`))}`,
-      );
-
-      vscode.window.showInformationMessage(
-        `Global state content: ${JSON.stringify(globalStateData)}`,
-      );
+    () => {
+      const formattedData = Object.entries(initialLanguagesData)
+        .map(([key, elapsedTime]) => `${key}: ${elapsedTime} seconds`)
+        .join("\n");
+      console.log(`Initial Languages Data:\n${formattedData}`);
     },
   );
 
@@ -43,18 +41,23 @@ const initExtensionCommands = (
     "MoonCode.showCurrentFilesData",
     () => {
       const { filesData: currentFilesData } = getTime();
-      vscode.window.showInformationMessage(
-        `currentFilesData: ${JSON.stringify(Object.entries(currentFilesData).map(([key, { elapsedTime }]) => `${key}: ${elapsedTime} seconds`))}`,
-      );
+      const formattedData = Object.entries(currentFilesData)
+        .map(([key, { elapsedTime }]) => `${key}: ${elapsedTime} seconds`)
+        .join("\n");
+      console.log(`Current files data:\n${formattedData}`);
     },
   );
 
   const showInitialFilesDataCommand = vscode.commands.registerCommand(
     "MoonCode.showInitialFilesData",
-    async () => {
-      vscode.window.showInformationMessage(
-        `initialFilesData from server: ${JSON.stringify(Object.entries(initialFilesData).map(([key, { timeSpent: elapsedTime }]) => `${key}: ${elapsedTime} seconds`))}`,
-      );
+    () => {
+      const formattedData = Object.entries(initialFilesData)
+        .map(
+          ([key, { timeSpent: elapsedTime }]) =>
+            `${key}: ${elapsedTime} seconds`,
+        )
+        .join("\n");
+      console.log(`InitialFilesData from server:\n${formattedData}`);
     },
   );
 
@@ -62,10 +65,7 @@ const initExtensionCommands = (
     "MoonCode.showGlobalStateData",
     async () => {
       const data = await getGlobalStateData();
-      console.log(data);
-      vscode.window.showInformationMessage(
-        `Global state data : ${JSON.stringify(data)}`,
-      );
+      console.dir(data, { depth: Infinity });
     },
   );
 
@@ -73,6 +73,13 @@ const initExtensionCommands = (
     "MoonCode.login",
     async () => {
       await login();
+    },
+  );
+
+  const logoutCommand = vscode.commands.registerCommand(
+    "MoonCode.logout",
+    async () => {
+      await logout();
     },
   );
 
@@ -88,6 +95,7 @@ const initExtensionCommands = (
     showCurrentFilesDataCommand,
     showGlobalStateContentCommand,
     loginCommand,
+    logoutCommand,
     openDashboardCommand,
     statusBarItem,
   );

--- a/apps/vscode-extension/src/utils/periodicSyncData.ts
+++ b/apps/vscode-extension/src/utils/periodicSyncData.ts
@@ -30,8 +30,7 @@ const periodicSyncData = async (
   );
 
   const timeSpentPerProject = Object.entries(getTime().filesData)
-    .map(([filePath, fileData]) => ({
-      filePath,
+    .map(([, fileData]) => ({
       project: fileData.projectPath,
       timeSpent: fileData.elapsedTime,
     }))
@@ -48,13 +47,17 @@ const periodicSyncData = async (
     );
   const todayFilesData = Object.fromEntries(
     Object.entries(getTime().filesData).map(
-      ([filePath, { elapsedTime, languageSlug, projectName, projectPath }]) => [
+      ([
+        filePath,
+        { elapsedTime, languageSlug, projectName, projectPath, fileName },
+      ]) => [
         filePath,
         {
           timeSpent: elapsedTime,
           languageSlug,
           projectName,
           projectPath,
+          fileName,
         },
       ],
     ),

--- a/packages/common/src/schemas.ts
+++ b/packages/common/src/schemas.ts
@@ -30,30 +30,11 @@ export const loginResponseSchema = z.object({
 });
 
 export const dateStringDto = z.string().refine(
-  (value) => {
-    const dateRegex = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
-    if (!dateRegex.test(value)) return false;
-
-    const [, month = "", day = "", year = ""] = dateRegex.exec(value) || [];
-    const monthNum = parseInt(month, 10);
-    const dayNum = parseInt(day, 10);
-    const yearNum = parseInt(year, 10);
-
-    // Check if the date is valid using Date object
-    const date = new Date(yearNum, monthNum - 1, dayNum);
-    const isValidDate =
-      date.getFullYear() === yearNum &&
-      date.getMonth() === monthNum - 1 &&
-      date.getDate() === dayNum;
-
-    return (
-      monthNum >= 1 &&
-      monthNum <= 12 &&
-      dayNum >= 1 &&
-      yearNum >= 1900 &&
-      yearNum <= 2100 &&
-      isValidDate
-    );
+  (dateStr) => {
+    const date = new Date(dateStr);
+    return !isNaN(date.getTime());
   },
-  { message: "String must be a valid date in MM/DD/YYYY format" },
+  {
+    message: "Invalid date string",
+  },
 );


### PR DESCRIPTION
## Commits

- [revert: login/logout](https://github.com/Friedrich482/mooncode/commit/2212ac0852d80cc0dd07ac96286936f3d9c83656)
	
	-  properly formatted the `compose.yaml` file in the environment section
	- reverted to the returning data from the upsertion of languages and files
	- reverted back the commands login and logout, the logout function and updated the `package.json`
	- augmented the `MAX_IDLE_TIME` to 5 mins
	- made the dateStringDto less strict

- [fix: returning data](https://github.com/Friedrich482/mooncode/commit/e246274aa1e12722a0dc29aff8daab089642a6b4)

	- brought back the returning data from the upsert functions regarding files and languages
	- re-initialize languages and files with those returning data so when the user logs out and logs back in, he can continue from where he was

- [fix: fileName](https://github.com/Friedrich482/mooncode/commit/b31727f506c1ea434aa9eaf558e846cd93101a19)

	- the fileName is directly got using **node: path** instead of  `const fileName = path.split("/").pop()!;` in the api (this old method only works properly on linux)
	- updated the `FileData` type, the schema of the globalState with fileName for all files
	- it is properly sent to the backend in the `periodicSyncData` function
	- updated the `initializeFiles` and `updateCurrentFile` functions to include those changes