### PR TITLE
chore: extension bump

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -57,6 +57,12 @@ Before continuing you'll need some environment variables: `JWT_TOKEN` and `DATAB
   ssh-keygen -t rsa -b 4096
   ```
 
+- `NODE_ENV`:
+
+  ```bash
+  NODE_ENV=production
+  ```
+
 ## Compile and run the project
 
 Compile :

--- a/apps/api/src/coding-stats/coding-stats-dashboard.service.ts
+++ b/apps/api/src/coding-stats/coding-stats-dashboard.service.ts
@@ -82,6 +82,7 @@ export class CodingStatsDashboardService {
       originalDate: new Date(date).toDateString(),
       date: getWeekDayName(date),
       timeSpentBar: timeSpent,
+      timeSpentArea: timeSpent,
       value: formatDuration(timeSpent),
     }));
   }

--- a/apps/api/src/coding-stats/utils/getDaysOfPeriodStatsGroupByMonths.ts
+++ b/apps/api/src/coding-stats/utils/getDaysOfPeriodStatsGroupByMonths.ts
@@ -40,6 +40,7 @@ const getDaysOfPeriodStatsGroupByMonths = (
     originalDate: month,
     date: month,
     timeSpentBar: timeSpent,
+    timeSpentArea: timeSpent,
     value: formatDuration(timeSpent),
   }));
 };

--- a/apps/api/src/coding-stats/utils/getDaysOfPeriodStatsGroupByWeeks.ts
+++ b/apps/api/src/coding-stats/utils/getDaysOfPeriodStatsGroupByWeeks.ts
@@ -79,6 +79,7 @@ const getDaysOfPeriodStatsGroupByWeeks = (
     originalDate: weekRange,
     date: weekRange,
     timeSpentBar: timeSpent,
+    timeSpentArea: timeSpent,
     value: formatDuration(timeSpent),
   }));
 };

--- a/apps/dashboard/src/components/dashboard-page/PeriodProjects.tsx
+++ b/apps/dashboard/src/components/dashboard-page/PeriodProjects.tsx
@@ -1,16 +1,17 @@
-import { Folder, FolderOpen } from "lucide-react";
+import { Folder, FolderOpen, LayoutGrid, List } from "lucide-react";
 import Icon from "@repo/ui/components/ui/Icon";
 import { Link } from "react-router";
 import { PERIODS_CONFIG } from "@/constants";
+import { cn } from "@repo/ui/lib/utils";
 import formatDuration from "@repo/common/formatDuration";
 import { usePeriodStore } from "@/hooks/store/periodStore";
+import { useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTRPC } from "@/utils/trpc";
 
 const PeriodProjects = () => {
   const period = usePeriodStore((state) => state.period);
   const customRange = usePeriodStore((state) => state.customRange);
-
   const trpc = useTRPC();
 
   const { data } = useSuspenseQuery(
@@ -27,9 +28,34 @@ const PeriodProjects = () => {
     ),
   );
 
+  const [isGridLayout, setIsGridLayout] = useState(true);
+  const handleGridLayoutButtonClick = () => setIsGridLayout(true);
+  const handleListLayoutButtonClick = () => setIsGridLayout(false);
+
   return (
     <div className="flex min-h-96 w-full flex-col gap-y-6 self-center rounded-md border p-3 text-2xl">
-      <h2 className="text-center text-2xl font-bold">Projects</h2>
+      <section className="flex items-center justify-center gap-2 pr-4">
+        <h2 className="flex-1 text-center text-2xl font-bold">Projects</h2>
+        <div className="space-x-2">
+          <Icon
+            Icon={LayoutGrid}
+            onClick={handleGridLayoutButtonClick}
+            className={cn(
+              isGridLayout &&
+                "bg-primary hover:bg-primary text-primary-foreground hover:text-primary-foreground",
+            )}
+          />
+          <Icon
+            Icon={List}
+            onClick={handleListLayoutButtonClick}
+            className={cn(
+              !isGridLayout &&
+                "bg-primary hover:bg-primary text-primary-foreground hover:text-primary-foreground",
+            )}
+          />
+        </div>
+      </section>
+
       {data.length === 0 ? (
         <p className="text-center text-xl">
           No projects found{" "}
@@ -43,26 +69,43 @@ const PeriodProjects = () => {
             `on ${period.toLowerCase()}`
           )}
         </p>
-      ) : (
+      ) : isGridLayout ? (
         <div className="grid grid-cols-2 gap-x-4 gap-y-8 max-[42rem]:grid-cols-1 max-[42rem]:gap-8">
           {data.map((entry) => (
             <Link key={entry.path} to={`/dashboard/${entry.name}`}>
-              <div className="group relative flex min-h-40 origin-bottom-right cursor-pointer flex-col items-center justify-center gap-4 rounded-md border p-3 transition-transform duration-150 hover:border-primary/85">
+              <div className="group hover:border-primary/85 relative flex min-h-40 origin-bottom-right cursor-pointer flex-col items-center justify-center gap-4 rounded-md border p-3 transition-transform duration-150">
                 <Icon
                   Icon={Folder}
-                  className="absolute -top-8 left-0 block text-border hover:bg-transparent group-hover:hidden"
+                  className="text-border absolute -top-8 left-0 block group-hover:hidden hover:bg-transparent"
                 />
                 <Icon
                   Icon={FolderOpen}
-                  className="absolute -top-8 left-0 hidden hover:bg-transparent hover:bg-none group-hover:block group-hover:text-primary/85"
+                  className="group-hover:text-primary/85 absolute -top-8 left-0 hidden group-hover:block hover:bg-transparent hover:bg-none"
                 />
                 <h3 className="font-bold group-hover:underline max-[42rem]:text-xl">
                   {entry.name}
                 </h3>
-                <p className="text-xl text-primary/85 transition duration-150 max-[42rem]:text-base">
+                <p className="text-primary/85 text-xl transition duration-150 max-[42rem]:text-base">
                   {formatDuration(entry.totalTimeSpent)} ({entry.percentage}%)
                 </p>
               </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-8">
+          {data.map((entry) => (
+            <Link
+              to={`/dashboard/${entry.name}`}
+              key={entry.name}
+              className="group hover:border-primary/85 relative flex items-center justify-center gap-4 rounded-md border p-2"
+            >
+              <h3 className="font-bold group-hover:underline max-[42rem]:text-xl">
+                {entry.name}
+              </h3>
+              <p className="text-primary/85 text-xl transition duration-150 max-[42rem]:text-base">
+                {formatDuration(entry.totalTimeSpent)} ({entry.percentage}%)
+              </p>
             </Link>
           ))}
         </div>

--- a/apps/dashboard/src/components/dashboard-page/charts/PeriodTimeChart.tsx
+++ b/apps/dashboard/src/components/dashboard-page/charts/PeriodTimeChart.tsx
@@ -1,21 +1,50 @@
-import { Bar, ComposedChart, Line, XAxis } from "recharts";
+import { Area, AreaChart, Bar, ComposedChart, Line, XAxis } from "recharts";
+import {
+  AreaChart as AreaChartIcon,
+  BarChart as BarChartIcon,
+} from "lucide-react";
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "@repo/ui/components/ui/chart";
 import { PERIODS_CONFIG, chartConfig } from "@/constants";
+import { RouterOutput, useTRPC } from "@/utils/trpc";
 import CustomChartToolTip from "@/components/CustomChartToolTip";
+import Icon from "@repo/ui/components/ui/Icon";
 import { Payload } from "recharts/types/component/DefaultTooltipContent";
 import { formatTickForGroupBy } from "@/utils/formatTickForGroupBy";
 import { usePeriodStore } from "@/hooks/store/periodStore";
+import { useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useTRPC } from "@/utils/trpc";
+
+type ChartDataType = RouterOutput["codingStats"]["getDaysOfPeriodStats"];
+
+const tooltipLabelFormatter = (
+  _date: string,
+  payload: Payload<string, string>[],
+) => {
+  if (payload.length === 0) return null;
+  const { payload: innerPayload }: { payload?: ChartDataType[number] } =
+    payload[0];
+
+  if (!innerPayload) return null;
+
+  return <div>{innerPayload.originalDate}</div>;
+};
+
+const tooltipFormatter = (value: string, name: string) =>
+  name === "Time"
+    ? CustomChartToolTip(parseInt(value), "var(--color-time)")
+    : null;
 
 const PeriodTimeChart = () => {
   const period = usePeriodStore((state) => state.period);
   const groupBy = usePeriodStore((state) => state.groupBy);
   const customRange = usePeriodStore((state) => state.customRange);
+  const [isBarChartVisible, setIsBarChartVisible] = useState(true);
+  const handleClick = () => setIsBarChartVisible((prev) => !prev);
+
   const trpc = useTRPC();
 
   const { data: chartData } = useSuspenseQuery(
@@ -36,57 +65,74 @@ const PeriodTimeChart = () => {
 
   return (
     <div className="max-chart:w-full relative z-0 flex min-h-96 w-[45%] flex-col rounded-md border">
+      <Icon
+        Icon={isBarChartVisible ? AreaChartIcon : BarChartIcon}
+        className="absolute -top-12 right-0 z-0"
+        onClick={handleClick}
+      />
+
       <ChartContainer
         config={chartConfig}
         className="h-full flex-1 border-none"
       >
-        <ComposedChart data={chartData}>
-          <XAxis
-            dataKey="date"
-            tickLine={false}
-            tickMargin={10}
-            axisLine={false}
-            tickFormatter={(value) => formatTickForGroupBy(value, groupBy)}
-          />
-          <ChartTooltip
-            content={<ChartTooltipContent labelClassName="font-semibold" />}
-            labelFormatter={(
-              _date: string,
-              payload: Payload<string, string>[],
-            ) => {
-              if (payload.length === 0) return null;
+        {isBarChartVisible ? (
+          <ComposedChart data={chartData}>
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+              tickFormatter={(value) => formatTickForGroupBy(value, groupBy)}
+            />
+            <ChartTooltip
+              content={<ChartTooltipContent labelClassName="font-semibold" />}
+              labelFormatter={tooltipLabelFormatter}
+              formatter={tooltipFormatter}
+            />
 
-              const {
-                payload: innerPayload,
-              }: { payload?: (typeof chartData)[number] } = payload[0];
+            <Bar
+              dataKey="timeSpentBar"
+              fill="var(--color-time)"
+              className="cursor-pointer"
+              name="Time"
+            />
 
-              if (!innerPayload) return null;
-
-              return <div>{innerPayload.originalDate}</div>;
-            }}
-            formatter={(value, name) =>
-              name === "Time"
-                ? CustomChartToolTip(parseInt(value), "var(--color-time)")
-                : null
-            }
-          />
-
-          <Bar
-            dataKey="timeSpentBar"
-            fill="var(--color-time)"
-            className="cursor-pointer"
-            name="Time"
-          />
-
-          <Line
-            dataKey="timeSpentLine"
-            stroke="var(--destructive)"
-            strokeWidth={2}
-            dot={{ r: 4 }}
-            type="monotone"
-            className="cursor-pointer"
-          />
-        </ComposedChart>
+            <Line
+              dataKey="timeSpentLine"
+              stroke="var(--destructive)"
+              strokeWidth={2}
+              dot={{ r: 4 }}
+              type="monotone"
+              className="cursor-pointer"
+            />
+          </ComposedChart>
+        ) : (
+          <AreaChart data={chartData}>
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+              tickFormatter={(value) => formatTickForGroupBy(value, groupBy)}
+            />
+            <ChartTooltip
+              content={<ChartTooltipContent labelClassName="font-semibold" />}
+              labelFormatter={tooltipLabelFormatter}
+              formatter={tooltipFormatter}
+            />
+            <Area
+              dataKey="timeSpentArea"
+              fill="var(--color-time)"
+              className="cursor-pointer"
+              name="Time"
+              stroke="var(--destructive)"
+              strokeWidth={2}
+              type="monotone"
+              fillOpacity={1}
+              dot={{ r: 4 }}
+            />
+          </AreaChart>
+        )}
       </ChartContainer>
     </div>
   );

--- a/apps/dashboard/src/components/project-page/charts/ProjectTimeOnPeriodChart.tsx
+++ b/apps/dashboard/src/components/project-page/charts/ProjectTimeOnPeriodChart.tsx
@@ -9,6 +9,7 @@ import {
   ChartTooltipContent,
 } from "@repo/ui/components/ui/chart";
 import { PERIODS_CONFIG, chartConfig } from "@/constants";
+import { RouterOutput, useTRPC } from "@/utils/trpc";
 import CustomChartToolTip from "@/components/CustomChartToolTip";
 import Icon from "@repo/ui/components/ui/Icon";
 import { Payload } from "recharts/types/component/DefaultTooltipContent";
@@ -18,7 +19,26 @@ import { usePeriodStore } from "@/hooks/store/periodStore";
 import useSafeParams from "@/hooks/useSafeParams";
 import { useState } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useTRPC } from "@/utils/trpc";
+
+type ChartDataType = RouterOutput["filesStats"]["getProjectPerDayOfPeriod"];
+
+const tooltipLabelFormatter = (
+  _date: string,
+  payload: Payload<string, string>[],
+) => {
+  if (payload.length === 0) return null;
+  const { payload: innerPayload }: { payload?: ChartDataType[number] } =
+    payload[0];
+
+  if (!innerPayload) return null;
+
+  return <div>{innerPayload.originalDate}</div>;
+};
+
+const tooltipFormatter = (value: string, name: string) =>
+  name === "Time"
+    ? CustomChartToolTip(parseInt(value), "var(--color-time)")
+    : null;
 
 const ProjectTimeOnPeriodChart = () => {
   const { projectName: name } = useSafeParams(ProjectParamsSchema);
@@ -73,25 +93,8 @@ const ProjectTimeOnPeriodChart = () => {
             />
             <ChartTooltip
               content={<ChartTooltipContent labelClassName="font-semibold" />}
-              labelFormatter={(
-                _date: string,
-                payload: Payload<string, string>[],
-              ) => {
-                if (payload.length === 0) return null;
-
-                const {
-                  payload: innerPayload,
-                }: { payload?: (typeof chartData)[number] } = payload[0];
-
-                if (!innerPayload) return null;
-
-                return <div>{innerPayload.originalDate}</div>;
-              }}
-              formatter={(value, name) =>
-                name === "Time"
-                  ? CustomChartToolTip(parseInt(value), "var(--color-time)")
-                  : null
-              }
+              labelFormatter={tooltipLabelFormatter}
+              formatter={tooltipFormatter}
             />
             <Bar
               dataKey="timeSpentBar"
@@ -120,25 +123,8 @@ const ProjectTimeOnPeriodChart = () => {
             />
             <ChartTooltip
               content={<ChartTooltipContent labelClassName="font-semibold" />}
-              labelFormatter={(
-                _date: string,
-                payload: Payload<string, string>[],
-              ) => {
-                if (payload.length === 0) return null;
-
-                const {
-                  payload: innerPayload,
-                }: { payload?: (typeof chartData)[number] } = payload[0];
-
-                if (!innerPayload) return null;
-
-                return <div>{innerPayload.originalDate}</div>;
-              }}
-              formatter={(value, name) =>
-                name === "Time"
-                  ? CustomChartToolTip(parseInt(value), "var(--color-time)")
-                  : null
-              }
+              labelFormatter={tooltipLabelFormatter}
+              formatter={tooltipFormatter}
             />
             <Area
               dataKey="timeSpentArea"

--- a/apps/dashboard/src/components/project-page/files-list/Files.tsx
+++ b/apps/dashboard/src/components/project-page/files-list/Files.tsx
@@ -99,10 +99,10 @@ const Files = memo(function Files({
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <div className="flex min-h-9 gap-4">
-                                  <span className="min-h-9 overflow-hidden text-ellipsis whitespace-nowrap font-extrabold">
+                                  <span className="min-h-9 overflow-hidden font-extrabold text-ellipsis whitespace-nowrap">
                                     &bull; {name}
                                   </span>
-                                  <span className="overflow-hidden text-ellipsis whitespace-nowrap font-extralight">
+                                  <span className="overflow-hidden font-extralight text-ellipsis whitespace-nowrap">
                                     {formatDuration(totalTimeSpent)}
                                   </span>
                                 </div>
@@ -126,10 +126,10 @@ const Files = memo(function Files({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div className="flex min-h-9 gap-4">
-                    <span className="min-h-9 overflow-hidden text-ellipsis whitespace-nowrap font-extrabold">
+                    <span className="min-h-9 overflow-hidden font-extrabold text-ellipsis whitespace-nowrap">
                       &bull; {name}
                     </span>
-                    <span className="overflow-hidden text-ellipsis whitespace-nowrap font-extralight">
+                    <span className="overflow-hidden font-extralight text-ellipsis whitespace-nowrap">
                       {formatDuration(totalTimeSpent)}
                     </span>
                   </div>

--- a/apps/dashboard/src/utils/trpc.ts
+++ b/apps/dashboard/src/utils/trpc.ts
@@ -1,5 +1,10 @@
 import type { AppRouter } from "@repo/trpc/router";
 import { createTRPCContext } from "@trpc/tanstack-react-query";
+import type { inferRouterOutputs } from "@trpc/server";
+
+type RouterOutput = inferRouterOutputs<AppRouter>;
 
 export const { TRPCProvider, useTRPC, useTRPCClient } =
   createTRPCContext<AppRouter>();
+
+export { type RouterOutput };

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mooncode",
   "displayName": "MoonCode",
   "description": "MoonCode is an extension that tracks your coding time (like WakaTime) and gives you a detailed summary about all your coding statistics. With MoonCode, developers get the full history of their coding activity.",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "icon": "./public/moon.png",
   "publisher": "Friedrich482",
   "author": {


### PR DESCRIPTION
## Commits

- [chore: extension bump](https://github.com/Friedrich482/mooncode/commit/98191e82171547a78151ff0cade718e38d5c5e48)
	- bumped the extension version to `v0.0.23`
	- updated the README of the api to include a section of the environment variable `NODE_ENV`

- [feat: charts](https://github.com/Friedrich482/mooncode/commit/719cdff73189a2da1abef43b5510e3bf6ebc2683)
	- added the AreaChart on the PeriodTimeChart and the proper changes on the backend in the `coding-stats-dashboard`
	- added the option to switch layouts (grid/list) in the `PeriodProjects` component on the dashboard page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard: Toggle between bar+line and area views on time charts.
  * Dashboard: Switch between grid and list layouts for project listings.
* **Refactor**
  * Standardized chart tooltips for clearer, consistent labels across views.
* **Documentation**
  * Added NODE_ENV setup guidance to the API README.
* **Chores**
  * Updated VS Code extension version to 0.0.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->