### PR TITLE
fix: bar, line and area charts, chore: logging  and fix: DayLanguagesChart 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@
 
 This project is the monorepo for MoonCode. This is an application to track and get a detailled summary about your coding time, languages, files across any period.
 
+## Features 🚀
+
+- Summary of coding time per day, week, month, year,... and any custom period
+- Support for most languages/files extensions
+- Breakdown of coding activity per project
+- Local dashboard to visualize your data, with extensive filters for a more detailed summary
+- All parts (vscode-extension, api, dashboard) of the project can be self-hosted
+- Extension Works offline 🔌
+
 ### Apps and Packages
 
 - [`api`](./apps/api): a [Nestjs](https://nestjs.com/) application that powers the `extension` and the `dashboard`

--- a/apps/api/src/coding-stats/coding-stats-dashboard.service.ts
+++ b/apps/api/src/coding-stats/coding-stats-dashboard.service.ts
@@ -6,7 +6,6 @@ import {
   GetPeriodLanguagesTimeDtoType,
   GetTimeSpentOnPeriodDtoType,
 } from "./coding-stats.dto";
-import { DATE_LOCALE } from "@repo/common/constants";
 import { DailyDataService } from "src/daily-data/daily-data.service";
 import { Injectable } from "@nestjs/common";
 import { LanguagesService } from "src/languages/languages.service";
@@ -21,7 +20,6 @@ import getGeneralStatsOnPeriodGroupByWeeks from "./utils/getGeneralStatsOnPeriod
 import getMostUsedLanguageOnPeriod from "./utils/getMostUsedLanguageOnPeriod";
 import getPeriodLanguagesGroupByMonths from "./utils/getPeriodLanguagesGroupByMonths";
 import getPeriodLanguagesGroupByWeeks from "src/coding-stats/utils/getPeriodLanguagesGroupByWeeks";
-import getTodaysLocalDate from "@repo/common/getTodaysLocalDate";
 import getWeekDayName from "src/utils/getWeekdayName";
 
 @Injectable()
@@ -182,21 +180,6 @@ export class CodingStatsDashboardService {
   ) {
     const { userId, dateString } = getDailyStatsForChartDto;
 
-    const providedDate = new Date(dateString);
-
-    const dateLabel =
-      dateString === getTodaysLocalDate()
-        ? "Today"
-        : // yesterday's date
-          dateString ===
-            new Date(
-              new Date().getFullYear(),
-              new Date().getMonth(),
-              new Date().getDate() - 1,
-            ).toLocaleDateString(DATE_LOCALE)
-          ? "Yesterday"
-          : providedDate.toDateString();
-
     const dayData = await this.dailyDataService.findOneDailyData({
       userId,
       date: dateString,
@@ -206,7 +189,6 @@ export class CodingStatsDashboardService {
       return {
         formattedTotalTimeSpent: formatDuration(0),
         finalData: [],
-        dateLabel,
       };
 
     const dayLanguagesTime = await this.languagesService.findAllLanguages({
@@ -229,7 +211,6 @@ export class CodingStatsDashboardService {
     return {
       finalData,
       formattedTotalTimeSpent,
-      dateLabel,
     };
   }
 

--- a/apps/api/src/trpc/trpc.service.ts
+++ b/apps/api/src/trpc/trpc.service.ts
@@ -84,7 +84,10 @@ export class TrpcService {
       );
       return payload;
     } catch (error) {
-      console.error(error);
+      if (error instanceof Error && error.name !== "JsonWebTokenError") {
+        console.error("Unexpected Error:", error);
+      }
+
       throw new TRPCError({
         code: "UNAUTHORIZED",
         message: "An error occurred",

--- a/apps/dashboard/src/components/dashboard-page/charts/PeriodTimeChart.tsx
+++ b/apps/dashboard/src/components/dashboard-page/charts/PeriodTimeChart.tsx
@@ -1,4 +1,12 @@
-import { Area, AreaChart, Bar, ComposedChart, Line, XAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  Cell,
+  ComposedChart,
+  Line,
+  XAxis,
+} from "recharts";
 import {
   AreaChart as AreaChartIcon,
   BarChart as BarChartIcon,
@@ -96,7 +104,15 @@ const PeriodTimeChart = () => {
               className="cursor-pointer"
               name="Time"
               key={`${chartData[0].originalDate}-${chartData.at(-1)?.originalDate}`}
-            />
+            >
+              {chartData.map((entry) => (
+                <Cell
+                  min={0}
+                  key={entry.originalDate}
+                  className="cursor-pointer"
+                />
+              ))}
+            </Bar>
 
             <Line
               dataKey="timeSpentLine"
@@ -105,7 +121,15 @@ const PeriodTimeChart = () => {
               dot={{ r: 4 }}
               type="monotone"
               className="cursor-pointer"
-            />
+            >
+              {chartData.map((entry) => (
+                <Cell
+                  min={0}
+                  key={entry.originalDate}
+                  className="cursor-pointer"
+                />
+              ))}
+            </Line>
           </ComposedChart>
         ) : (
           <AreaChart data={chartData}>
@@ -132,7 +156,15 @@ const PeriodTimeChart = () => {
               fillOpacity={1}
               dot={{ r: 4 }}
               key={`${chartData[0].originalDate}-${chartData.at(-1)?.originalDate}`}
-            />
+            >
+              {chartData.map((entry) => (
+                <Cell
+                  min={0}
+                  key={entry.originalDate}
+                  className="cursor-pointer"
+                />
+              ))}
+            </Area>
           </AreaChart>
         )}
       </ChartContainer>

--- a/apps/dashboard/src/components/dashboard-page/charts/dayLanguagesChart/DayLanguagesChart.tsx
+++ b/apps/dashboard/src/components/dashboard-page/charts/dayLanguagesChart/DayLanguagesChart.tsx
@@ -13,6 +13,7 @@ import getLanguageColor from "@repo/ui/utils/getLanguageColor";
 import getLanguageName from "@repo/ui/utils/getLanguageName";
 import getNextDayDate from "@/utils/getNextDayDate";
 import getPrevDayDate from "@/utils/getPreviousDayDate";
+import getTodaysLocalDate from "@repo/common/getTodaysLocalDate";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTRPC } from "@/utils/trpc";
 
@@ -34,7 +35,20 @@ const DayLanguagesChart = () => {
     }),
   );
 
-  const { finalData, formattedTotalTimeSpent, dateLabel: displayDate } = data;
+  const displayDate =
+    dateString === getTodaysLocalDate()
+      ? "Today"
+      : // yesterday's date
+        dateString ===
+          new Date(
+            new Date().getFullYear(),
+            new Date().getMonth(),
+            new Date().getDate() - 1,
+          ).toLocaleDateString(DATE_LOCALE)
+        ? "Yesterday"
+        : new Date(dateString).toDateString();
+
+  const { finalData, formattedTotalTimeSpent } = data;
 
   const chartData = finalData.map((entry) => ({
     ...entry,
@@ -43,7 +57,7 @@ const DayLanguagesChart = () => {
   }));
 
   return (
-    <div className="flex min-h-96 w-[45%] flex-col gap-y-2 rounded-md border py-2 max-chart:w-full">
+    <div className="max-chart:w-full flex min-h-96 w-[45%] flex-col gap-y-2 rounded-md border py-2">
       <ChartTitle
         displayDate={displayDate}
         formattedTotalTimeSpent={formattedTotalTimeSpent}

--- a/apps/dashboard/src/components/project-page/charts/ProjectTimeOnPeriodChart.tsx
+++ b/apps/dashboard/src/components/project-page/charts/ProjectTimeOnPeriodChart.tsx
@@ -1,4 +1,12 @@
-import { Area, AreaChart, Bar, ComposedChart, Line, XAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  Cell,
+  ComposedChart,
+  Line,
+  XAxis,
+} from "recharts";
 import {
   AreaChart as AreaChartIcon,
   BarChart as BarChartIcon,
@@ -102,7 +110,15 @@ const ProjectTimeOnPeriodChart = () => {
               className="cursor-pointer"
               name="Time"
               key={`${chartData[0].originalDate}-${chartData.at(-1)?.originalDate}`}
-            />
+            >
+              {chartData.map((entry) => (
+                <Cell
+                  min={0}
+                  key={entry.originalDate}
+                  className="cursor-pointer"
+                />
+              ))}
+            </Bar>
 
             <Line
               dataKey="timeSpentLine"
@@ -111,7 +127,15 @@ const ProjectTimeOnPeriodChart = () => {
               dot={{ r: 4 }}
               type="monotone"
               className="cursor-pointer"
-            />
+            >
+              {chartData.map((entry) => (
+                <Cell
+                  min={0}
+                  key={entry.originalDate}
+                  className="cursor-pointer"
+                />
+              ))}
+            </Line>
           </ComposedChart>
         ) : (
           <AreaChart data={chartData}>
@@ -138,7 +162,15 @@ const ProjectTimeOnPeriodChart = () => {
               fillOpacity={1}
               dot={{ r: 4 }}
               key={`${chartData[0].originalDate}-${chartData.at(-1)?.originalDate}`}
-            />
+            >
+              {chartData.map((entry) => (
+                <Cell
+                  min={0}
+                  key={entry.originalDate}
+                  className="cursor-pointer"
+                />
+              ))}
+            </Area>
           </AreaChart>
         )}
       </ChartContainer>

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mooncode",
   "displayName": "MoonCode",
   "description": "MoonCode is an extension that tracks your coding time (like WakaTime) and gives you a detailed summary about all your coding statistics. With MoonCode, developers get the full history of their coding activity.",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "icon": "./public/moon.png",
   "publisher": "Friedrich482",
   "author": {


### PR DESCRIPTION
## Commits

- [fix: bar, line and area charts](https://github.com/Friedrich482/mooncode/commit/e38ec463d34cfaf58da7c2f485adb3afb868977c)

	- in the components that use dynamic data such as `PeriodTimeChart` and `ProjectTimeOnPeriodChart`, use Cell to force recharts to generate the bar/area/line when we change day
	- bumped the extension version to 0.0.24
	- added complementary information in the README of the root project
	
- [chore: logging](https://github.com/Friedrich482/mooncode/commit/6d0ccf2d785eb608bf3965a30d96df2413eb756d)
	- removed the logs of errors related to JWT

- [fix: DayLanguagesChart](https://github.com/Friedrich482/mooncode/commit/78cf696a455c6ffd181f30a89adfd556430fde5d)
	-  fixed the displayDate of the DayLanguages by moving it to the client side to avoid dates mismatches between the client and server timezones