### PR TITLE
chore: typescript build file

### DIFF
--- a/apps/vscode-extension/README.md
+++ b/apps/vscode-extension/README.md
@@ -8,8 +8,10 @@ MoonCode is an extension that tracks your coding time (like WakaTime) and gives 
 <a href="https://marketplace.visualstudio.com/items?itemName=Friedrich482.mooncode">https://marketplace.visualstudio.com/items?itemName=Friedrich482.mooncode</a>  
 </p>
 <p align="center">
-  <img src="https://img.shields.io/visual-studio-marketplace/v/Friedrich482.mooncode?color=yellow&label=version" alt="VSCode Marketplace version">  
-  <img src="https://img.shields.io/badge/LICENSE-MIT-yellow" alt="MIT License">
+
+![VSCode Marketplace version](https://vsmarketplacebadges.dev/version/Friedrich482.mooncode.svg?label=version&color=yellow)
+![MIT License](https://img.shields.io/badge/LICENSE-MIT-yellow)
+
 </p>
 
 **⚠️ MoonCode is still in development so breaking changes may happen. But any feedback is welcomed !**
@@ -70,4 +72,4 @@ Chore:
 
 ## License
 
-[MIT](/LICENSE) License &copy; 2025
+[MIT](/LICENSE) License &copy; 2026

--- a/apps/vscode-extension/build.ts
+++ b/apps/vscode-extension/build.ts
@@ -1,9 +1,8 @@
-//@ts-check
-"use strict";
+/* eslint-disable no-console */
 
-const esbuild = require("esbuild");
-const path = require("path");
-const fs = require("fs");
+import esbuild, { Plugin } from "esbuild";
+import fs from "fs";
+import path from "path";
 
 const production = process.argv.includes("--production");
 const watch = process.argv.includes("--watch");
@@ -41,10 +40,7 @@ async function copyDashboard() {
     });
 
     // Get folder size for logging
-    /**
-     * @type {(dir: string) => number}
-     */
-    const getDirSize = (dir) => {
+    const getDirSize = (dir: string) => {
       let size = 0;
       const files = fs.readdirSync(dir);
       for (const file of files) {
@@ -66,21 +62,18 @@ async function copyDashboard() {
       `[dashboard] Dashboard files copied successfully ✓ (${dashboardSizeKB} KB)`,
     );
   } catch (error) {
-    console.error(`✘ [ERROR] Failed to copy dashboard files:`, error.message);
+    console.error(
+      `✘ [ERROR] Failed to copy dashboard files:`,
+      error instanceof Error ? error.message : error,
+    );
     process.exit(1);
   }
 }
 
-/**
- * @type {import('esbuild').Plugin}
- */
-const esbuildProblemMatcherPlugin = {
+const esbuildProblemMatcherPlugin: Plugin = {
   name: "esbuild-problem-matcher",
   setup(build) {
-    /**
-     * @type {number}
-     */
-    let startTime;
+    let startTime: number;
 
     build.onStart(() => {
       startTime = Date.now();
@@ -93,7 +86,7 @@ const esbuildProblemMatcherPlugin = {
         console.error(`✘ [ERROR] ${text}`);
         if (location) {
           console.error(
-            `    ${location.file}:${location.line}:${location.column}:`,
+            `${location.file}:${location.line}:${location.column}:`,
           );
         }
       });
@@ -117,10 +110,7 @@ const esbuildProblemMatcherPlugin = {
   },
 };
 
-/**
- * @type {import('esbuild').Plugin}
- */
-const aliasPlugin = {
+const aliasPlugin: Plugin = {
   name: "alias",
   setup(build) {
     build.onResolve({ filter: /^@repo\/utils$/ }, () => ({
@@ -148,7 +138,7 @@ async function main() {
     outfile: "dist/extension.js",
 
     minify: production,
-    sourcemap: production ? false : true,
+    sourcemap: !production,
     sourcesContent: false,
 
     external: ["vscode"],
@@ -161,7 +151,7 @@ async function main() {
 
     logLevel: "info",
 
-    target: "node16",
+    target: "esnext",
   });
 
   if (watch) {

--- a/apps/vscode-extension/build.ts
+++ b/apps/vscode-extension/build.ts
@@ -151,7 +151,7 @@ async function main() {
 
     logLevel: "info",
 
-    target: "esnext",
+    target: "node22",
   });
 
   if (watch) {

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -112,20 +112,20 @@
   "scripts": {
     "vscode:prepublish": "npm run package",
     "publish:patch": "vsce publish patch",
-    "compile": "node build.js",
+    "compile": "npx tsx build.ts",
     "build": "tsc --build",
-    "watch": "node build.js --watch",
-    "package": "node build.js --production",
+    "watch": "npx tsx build.ts --watch",
+    "package": "npx tsx build.ts --production",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
-    "lint": "eslint src --ext ts --fix",
+    "lint": "eslint src build.ts --fix",
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
     "@types/dotenv": "^6.1.1",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^20.19.32",
+    "@types/node": "^20.19.39",
     "@types/vscode": "^1.109.0",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
@@ -135,6 +135,7 @@
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.25.8",
     "eslint": "^9.39.2",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mooncode",
   "displayName": "MoonCode",
   "description": "MoonCode is an extension that tracks your coding time (like WakaTime) and gives you a detailed summary about all your coding statistics. With MoonCode, developers get the full history of their coding activity.",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "icon": "./public/moon.png",
   "publisher": "Friedrich482",
   "author": {

--- a/apps/vscode-extension/src/utils/auth/login.ts
+++ b/apps/vscode-extension/src/utils/auth/login.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "crypto";
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 import { getDashboardServer, getExtensionContext } from "@/extension";
 

--- a/apps/vscode-extension/src/utils/auth/store-jwt-token.ts
+++ b/apps/vscode-extension/src/utils/auth/store-jwt-token.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import vscode from "vscode";
 import { z } from "zod";
 
 import { getExtensionContext } from "@/extension";

--- a/apps/vscode-extension/src/utils/commands/init-extension-commands.ts
+++ b/apps/vscode-extension/src/utils/commands/init-extension-commands.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 import { getExtensionContext, getStatusBarItem } from "@/extension";
 import { FileDataSync } from "@/types-schemas";

--- a/apps/vscode-extension/src/utils/dashboard/open-dashboard.ts
+++ b/apps/vscode-extension/src/utils/dashboard/open-dashboard.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 import { getDashboardServer } from "@/extension";
 

--- a/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-dev.ts
+++ b/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-dev.ts
@@ -1,5 +1,5 @@
 import getPort from "get-port";
-import * as vscode from "vscode";
+import vscode from "vscode";
 import { WebSocket, WebSocketServer } from "ws";
 
 import { getExtensionContext } from "@/extension";

--- a/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-prod.ts
+++ b/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-prod.ts
@@ -2,7 +2,7 @@ import express from "express";
 import getPort from "get-port";
 import * as http from "http";
 import * as path from "path";
-import * as vscode from "vscode";
+import vscode from "vscode";
 import { WebSocket, WebSocketServer } from "ws";
 
 import { getExtensionContext } from "@/extension";

--- a/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard.ts
+++ b/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 import { getExtensionContext } from "@/extension";
 import { DashboardServer } from "@/types-schemas";

--- a/apps/vscode-extension/src/utils/files/get-current-file-properties.ts
+++ b/apps/vscode-extension/src/utils/files/get-current-file-properties.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 export const getCurrentFileProperties = (
   document: vscode.TextDocument | undefined,

--- a/apps/vscode-extension/src/utils/files/update-current-file-obj.ts
+++ b/apps/vscode-extension/src/utils/files/update-current-file-obj.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 import { filesData } from "@/constants";
 

--- a/apps/vscode-extension/src/utils/global-state/get-global-state-data.ts
+++ b/apps/vscode-extension/src/utils/global-state/get-global-state-data.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import vscode from "vscode";
 import { ZodError } from "zod";
 
 import { SYNC_DATA_KEY } from "@/constants";

--- a/apps/vscode-extension/src/utils/periodic-sync-data.ts
+++ b/apps/vscode-extension/src/utils/periodic-sync-data.ts
@@ -1,5 +1,5 @@
 import { isEqual } from "date-fns";
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 import { getLocaleDate } from "@repo/common/get-locale-date";
 import { TRPCClientError } from "@trpc/client";

--- a/apps/vscode-extension/src/utils/time/calculate-time.ts
+++ b/apps/vscode-extension/src/utils/time/calculate-time.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import vscode from "vscode";
 
 import { getExtensionContext } from "@/extension";
 import { FileMap } from "@/types-schemas";

--- a/apps/vscode-extension/tsconfig.json
+++ b/apps/vscode-extension/tsconfig.json
@@ -16,5 +16,5 @@
     "strict": true,
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "build.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,7 @@
     },
     "apps/vscode-extension": {
       "name": "mooncode",
-      "version": "0.0.60",
+      "version": "0.0.61",
       "license": "MIT",
       "dependencies": {
         "@repo/common": "*",
@@ -172,7 +172,7 @@
       "devDependencies": {
         "@types/dotenv": "^6.1.1",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^20.19.32",
+        "@types/node": "^20.19.39",
         "@types/vscode": "^1.109.0",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
@@ -182,6 +182,7 @@
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.25.8",
         "eslint": "^9.39.2",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -189,9 +190,9 @@
       }
     },
     "apps/vscode-extension/node_modules/@types/node": {
-      "version": "20.19.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
-      "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26354,6 +26355,510 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/packages/ui/src/colors.json
+++ b/packages/ui/src/colors.json
@@ -293,6 +293,7 @@
   "ini": { "name": "INI", "color": "#d1dbe0" },
   "ink": { "name": "Ink", "color": "#755B91" },
   "inno Setup": { "name": "Inno Setup", "color": "#264b99" },
+  "instructions": { "name": "Instructions", "color": "#083fa1" },
   "io": { "name": "Io", "color": "#a9188d" },
   "ioke": { "name": "Ioke", "color": "#078193" },
   "isabelle": { "name": "Isabelle", "color": "#FEFE00" },


### PR DESCRIPTION
## Commits

- [chore: typescript build file](https://github.com/Friedrich482/mooncode/commit/08b2e27006687182d3039e41abcdb22bc6a650c0)
	- converted the `build.js` configuration file of the extension to a `build.ts` file, which is also type checked (tsconfig)
	- migrated to `tsx` to run that file instead of `node`, installed `tsx` as a dev dependency

- [fix: badge](https://github.com/Friedrich482/mooncode/commit/bc4370f3aed353e1a8520dc7211559f0672d31fc)
	- fixed the broken version badge in the readme of the vscode extension

- [feat: instructions identification](https://github.com/Friedrich482/mooncode/commit/3eb4f048e8b6b9bf9058517c6f0e06d537f270e9)
	- added the instructions language slug in the colors.json file to properly display them in the frontend (dashboard), same color as markdown files

- [chore: extension version](https://github.com/Friedrich482/mooncode/commit/f44ed53fd8ce9d38fa20d4138cb6766adf8ac9e4)
	- bumped the extension version to `v0.0.62`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped VS Code extension version to 0.0.62
  * Updated build tooling and development dependencies
  * Modernized internal module imports

* **Documentation**
  * Updated README badges and formatting
  * Refreshed copyright information

* **New Features**
  * Added new "Instructions" color to design system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->