### PR TITLE
fix: update after sync

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mooncode",
   "displayName": "MoonCode",
   "description": "MoonCode is an extension that tracks your coding time (like WakaTime) and gives you a detailed summary about all your coding statistics. With MoonCode, developers get the full history of their coding activity.",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "icon": "./public/moon.png",
   "publisher": "Friedrich482",
   "author": {

--- a/apps/vscode-extension/src/types-schemas.ts
+++ b/apps/vscode-extension/src/types-schemas.ts
@@ -5,10 +5,10 @@ import { IsoDateStringSchema } from "@repo/common/types-schemas";
 /**
  * A file is marked as frozen when it is no longer the active file or if it is the active file but the user is inactive in the file for more than `MAX_IDLE_TIME` seconds
  * - `frozenTime` is an accumulator of time to track the elapsedTime on a file when the language is frozen
- * - `freezeStartTime` is the time when the file is marked as frozen
+ * - `freezeStartTime` is the moment when the file is marked as frozen
  * - `startTime` is the moment we start counting the time for that file
  * - `lastActivityTime` is the moment when the file is no longer focused, i.e no longer the active file
- * - `elapsedTime` is the time elapsed in total and what we send to the server/ save in the global state
+ * - `elapsedTime` is the time elapsed in total and what we send to the server/save in the global state
  * - `isFrozen` is a boolean to freeze/unfreeze the file
  */
 export type FileData = {

--- a/apps/vscode-extension/src/utils/commands/init-extension-commands.ts
+++ b/apps/vscode-extension/src/utils/commands/init-extension-commands.ts
@@ -7,7 +7,7 @@ import { login } from "../auth/login";
 import { logout } from "../auth/logout";
 import { openDashboard } from "../dashboard/open-dashboard";
 import { getGlobalStateData } from "../global-state/get-global-state-data";
-import { logDir, logInfo } from "../logger/logger";
+import { logInfo } from "../logger/logger";
 import { calculateTime } from "../time/calculate-time";
 
 export const initExtensionCommands = (
@@ -69,10 +69,9 @@ export const initExtensionCommands = (
     "MoonCode.showRawFilesDataCommand",
     () => {
       const filesData = getTime();
-      const formattedData = Object.entries(filesData)
-        .map(([key, fileData]) => `${key}:${JSON.stringify(fileData, null, 2)}`)
-        .join("\n");
-      logInfo(`Raw files Data computed:\n${formattedData}`);
+      logInfo(
+        `Raw files Data computed:\n${JSON.stringify(filesData, null, 2)}`,
+      );
     },
   );
 
@@ -93,7 +92,7 @@ export const initExtensionCommands = (
     "MoonCode.showGlobalStateData",
     async () => {
       const data = await getGlobalStateData();
-      logDir(data);
+      logInfo(`Global State data: ${JSON.stringify(data, null, 2)}`);
     },
   );
 

--- a/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-dev.ts
+++ b/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-dev.ts
@@ -35,7 +35,7 @@ export const serveDashboardDev = async () => {
         const data = JSON.parse(message.toString());
         const validated = WsDataSchema.safeParse(data);
         if (!validated.success) {
-          console.error("Invalid message shape");
+          logError("Invalid message shape");
           return;
         }
 

--- a/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-prod.ts
+++ b/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-prod.ts
@@ -59,7 +59,7 @@ export const serveDashboardProd = async () => {
         }
 
         logInfo("Received from dashboard:");
-        logDir(data);
+        logDir(validated.data);
 
         const { type } = validated.data;
 

--- a/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-prod.ts
+++ b/apps/vscode-extension/src/utils/dashboard/serve-dashboard/serve-dashboard-prod.ts
@@ -54,7 +54,7 @@ export const serveDashboardProd = async () => {
         const data = JSON.parse(message.toString());
         const validated = WsDataSchema.safeParse(data);
         if (!validated.success) {
-          console.error("Invalid message shape");
+          logError("Invalid message shape");
           return;
         }
 

--- a/apps/vscode-extension/src/utils/files/update-files-data-after-sync.ts
+++ b/apps/vscode-extension/src/utils/files/update-files-data-after-sync.ts
@@ -12,6 +12,13 @@ export const updateFilesDataAfterSync = (
 
     if (filesData[filePath]) {
       filesData[filePath].elapsedTime = file.timeSpent;
+
+      if (!filesData[filePath].isFrozen) {
+        filesData[filePath].startTime = now - file.timeSpent * 1000;
+        return;
+      }
+
+      filesData[filePath].frozenTime = file.timeSpent;
       return;
     }
 

--- a/apps/vscode-extension/src/utils/files/update-files-data-elapsed-time.ts
+++ b/apps/vscode-extension/src/utils/files/update-files-data-elapsed-time.ts
@@ -6,8 +6,10 @@ export const updateFilesDataElapsedTime = () => {
 
   Object.keys(filesData).forEach((filePath) => {
     const fileData = filesData[filePath];
+
     // Only use frozenTime if it is not null (0 is valid)
     fileData.elapsedTime =
+      // we check if the file is in a frozen state or not
       fileData.isFrozen && fileData.frozenTime !== null
         ? fileData.frozenTime
         : Math.floor((now - fileData.startTime) / 1000);

--- a/apps/vscode-extension/src/utils/files/update-files-data-frozen-states.ts
+++ b/apps/vscode-extension/src/utils/files/update-files-data-frozen-states.ts
@@ -13,9 +13,7 @@ export const updateFilesDataFrozenStates = () => {
 
   Object.keys(filesData).forEach((filePath) => {
     const fileData = filesData[filePath];
-    /**
-     * immediately freeze non active files
-     */
+    // immediately freeze non active files
     if (
       !latestFile ||
       !latestFile.absolutePath ||
@@ -31,17 +29,13 @@ export const updateFilesDataFrozenStates = () => {
 
     const latestFileObj = filesData[latestFile.absolutePath];
 
-    /**
-     *  We track the time elapsed since when the latest file has been modified
-     *  in a variable called `idleDuration`
-     */
+    // We track the time elapsed since when the latest file has been modified
+    // in a variable called `idleDuration`
     const idleDuration = Math.floor(
       (now - latestFileObj.lastActivityTime) / 1000,
     );
 
-    /**
-     * we freeze the time for the active file if the user is idling for more than `MAX_IDLE_TIME`
-     */
+    // we freeze the time for the active file if the user is idling for more than `MAX_IDLE_TIME`
     if (idleDuration >= MAX_IDLE_TIME && !latestFileObj.isFrozen) {
       latestFileObj.frozenTime = Math.floor(
         (now - latestFileObj.startTime) / 1000,
@@ -49,10 +43,8 @@ export const updateFilesDataFrozenStates = () => {
       latestFileObj.freezeStartTime = now;
       latestFileObj.isFrozen = true;
     } else if (
-      /**
-       * we unfreeze if it is active,
-       * marked as frozen and if the user hasn't been idled for more than `MAX_IDLE_TIME` seconds
-       */
+      // we unfreeze if it is active, marked as frozen and
+      // if the user hasn't been idled for more than `MAX_IDLE_TIME` seconds
       idleDuration < MAX_IDLE_TIME &&
       latestFileObj.isFrozen &&
       latestFileObj.freezeStartTime

--- a/apps/vscode-extension/src/utils/global-state/get-global-state-data.ts
+++ b/apps/vscode-extension/src/utils/global-state/get-global-state-data.ts
@@ -1,5 +1,4 @@
 import vscode from "vscode";
-import { ZodError } from "zod";
 
 import { SYNC_DATA_KEY } from "@/constants";
 import { getExtensionContext } from "@/extension";
@@ -17,15 +16,15 @@ export const getGlobalStateData: () => Promise<GlobalStateData> = async () => {
   const context = getExtensionContext();
   const todaysDateString = getLocaleDate(new Date());
 
-  try {
-    const globalStateData = globalStateInitialDataSchema.parse(
-      await context.globalState.get(SYNC_DATA_KEY),
-    );
+  const parsedGlobalStateData = globalStateInitialDataSchema.safeParse(
+    await context.globalState.get(SYNC_DATA_KEY),
+  );
 
-    return globalStateData;
-  } catch (error) {
+  if (!parsedGlobalStateData.success) {
+    const error = formatZodError(parsedGlobalStateData.error);
+
     vscode.window.showErrorMessage(
-      `Invalid data shape: ${error instanceof ZodError ? formatZodError(error) : error}. Defaulting to default data`,
+      `Invalid data shape: ${error}. Defaulting to default data`,
     );
 
     return {
@@ -40,4 +39,8 @@ export const getGlobalStateData: () => Promise<GlobalStateData> = async () => {
       },
     };
   }
+
+  const { data: globalStateData } = parsedGlobalStateData;
+
+  return globalStateData;
 };

--- a/apps/vscode-extension/src/utils/periodic-sync-data.ts
+++ b/apps/vscode-extension/src/utils/periodic-sync-data.ts
@@ -50,11 +50,7 @@ export const periodicSyncData = async (
     }))
     .reduce(
       (acc, curr) => {
-        if (acc[curr.project]) {
-          acc[curr.project] += curr.timeSpent;
-        } else {
-          acc[curr.project] = curr.timeSpent;
-        }
+        acc[curr.project] = (acc[curr.project] || 0) + curr.timeSpent;
         return acc;
       },
       {} as Record<string, number>,

--- a/apps/vscode-extension/src/utils/periodic-sync-data.ts
+++ b/apps/vscode-extension/src/utils/periodic-sync-data.ts
@@ -43,18 +43,13 @@ export const periodicSyncData = async (
 
   timeSpentPerLanguage = timeSpentPerLanguageToday;
 
-  const timeSpentPerProjectToday = Object.entries(filesDataToUpsert)
-    .map(([, fileData]) => ({
-      project: fileData.projectPath,
-      timeSpent: fileData.elapsedTime,
-    }))
-    .reduce(
-      (acc, curr) => {
-        acc[curr.project] = (acc[curr.project] || 0) + curr.timeSpent;
-        return acc;
-      },
-      {} as Record<string, number>,
-    );
+  const timeSpentPerProjectToday = Object.values(filesDataToUpsert).reduce(
+    (acc, { projectPath, elapsedTime }) => {
+      acc[projectPath] = (acc[projectPath] || 0) + elapsedTime;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
 
   const todayFilesData = Object.fromEntries(
     Object.entries(filesDataToUpsert).map(

--- a/apps/vscode-extension/src/utils/periodic-sync-data.ts
+++ b/apps/vscode-extension/src/utils/periodic-sync-data.ts
@@ -43,7 +43,7 @@ export const periodicSyncData = async (
 
   timeSpentPerLanguage = timeSpentPerLanguageToday;
 
-  const timeSpentPerProject = Object.entries(filesDataToUpsert)
+  const timeSpentPerProjectToday = Object.entries(filesDataToUpsert)
     .map(([, fileData]) => ({
       project: fileData.projectPath,
       timeSpent: fileData.elapsedTime,
@@ -116,7 +116,7 @@ export const periodicSyncData = async (
     const files = await trpc.extension.upsertFiles.mutate({
       filesData: todayFilesData,
       targetedDate: todaysDateString,
-      timeSpentPerProject,
+      timeSpentPerProject: timeSpentPerProjectToday,
     });
     updateFilesDataAfterSync(files);
 

--- a/apps/vscode-extension/src/utils/periodic-sync-data.ts
+++ b/apps/vscode-extension/src/utils/periodic-sync-data.ts
@@ -58,11 +58,17 @@ export const periodicSyncData = async (
 
   const todayFilesData = Object.fromEntries(
     Object.entries(filesDataToUpsert).map(
-      ([filePath, { elapsedTime, ...rest }]) => [
+      ([
+        filePath,
+        { elapsedTime, languageSlug, projectName, projectPath, fileName },
+      ]) => [
         filePath,
         {
           timeSpent: elapsedTime,
-          ...rest,
+          languageSlug,
+          projectName,
+          projectPath,
+          fileName,
         },
       ],
     ),


### PR DESCRIPTION
## Commits

- [fix: update after sync](https://github.com/Friedrich482/mooncode/commit/5ad0c48e4a056764c5bcd08c86a75d68257cb8fa)
	- fixed the weird issue of the local data not being properly updated after a sync with the server, that could cause stale data locally, by handling the two cases (file frozen or not)
	- fixed some comments issues in `types-schemas`, `update-files-data-frozen-states` and `update-files-data-elapsed-time`
	- used the `logError` utility function instead of a raw console.error in the `server-dashboard-prod` and `serve-dashboard-dev` functions
	- in the `get-global-state-data` function, we now schema.safeParse to validate the data instead of schema.parse and handle it directly to avoid using a try/catch block

- [fix: data payload](https://github.com/Friedrich482/mooncode/commit/521c46a9b352f14e636259b3036338a2d0261bb1)
	- only kept the necessary properties in the `todayFilesData` object sent to the api in the `periodicSyncData` function

- [chore: variable naming](https://github.com/Friedrich482/mooncode/commit/6f603ba615a870427176be8d17d2afa0d7cc5e45)
	- renamed the `timeSpentPerProject` to `timeSpentPerProjectToday` for clarity in the `periodicSyncData` function

- [chore: extension version](https://github.com/Friedrich482/mooncode/commit/4b69c1826e6ff4aec94807f82575b6a396f61db3)
	- bumped the extension version to `v0.0.63`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.0.63

* **Bug Fixes**
  * Improved handling of elapsed time calculation for frozen files during sync operations
  * Enhanced error reporting consistency across dashboard services

* **Documentation**
  * Updated type documentation for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->