### PR TITLE
Production header logging

### DIFF
--- a/apps/api/src/trpc/trpc.service.ts
+++ b/apps/api/src/trpc/trpc.service.ts
@@ -121,7 +121,8 @@ export class TrpcService {
       this.envService.get("NODE_ENV") === "development"
         ? ctx.req.ip
         : // the api may be behind proxies in production
-          (ctx.req.headers["x-forwarded-for"]
+          // it is actually proxied by cloudflare
+          (ctx.req.headers["cf-connecting-ip"]
             ?.toString()
             .split(",")[0]
             .trim() ?? ctx.req.socket.remoteAddress);


### PR DESCRIPTION
## Commits

- [fix: logged header](https://github.com/Friedrich482/mooncode/commit/a381c962986eed18e8516b0874ff80330279056a)
	- updated the header logged in production from `x-forwarded-for` to `cf-connecting-ip` because the api is now behind cloudflare proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client IP detection to accurately identify requests routed through Cloudflare infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->