### PR TITLE
fix: add theme-aware background colors to status bar for logged-out state

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mooncode",
   "displayName": "MoonCode",
   "description": "MoonCode is an extension that tracks your coding time (like WakaTime) and gives you a detailed summary about all your coding statistics. With MoonCode, developers get the full history of their coding activity.",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "icon": "./public/moon.png",
   "publisher": "Friedrich482",
   "author": {

--- a/apps/vscode-extension/src/utils/status-bar/set-status-bar-item.ts
+++ b/apps/vscode-extension/src/utils/status-bar/set-status-bar-item.ts
@@ -1,3 +1,5 @@
+import { ThemeColor } from "vscode";
+
 import { getStatusBarItem } from "@/extension";
 import { formatDuration } from "@repo/common/format-duration";
 
@@ -16,6 +18,9 @@ export const setStatusBarItem = (item: SetStatusBarItem) => {
   if (item.type === "time") {
     const { timeSpentToday } = item;
     statusBarItem.text = `$(watch) ${formatDuration(timeSpentToday)}`;
+    statusBarItem.backgroundColor = new ThemeColor(
+      "statusBarItem.activeBackground",
+    );
     statusBarItem.tooltip =
       "MoonCode: Time spent coding today. Click to open your dashboard";
     statusBarItem.command = "MoonCode.openDashboard";
@@ -24,7 +29,10 @@ export const setStatusBarItem = (item: SetStatusBarItem) => {
   }
 
   statusBarItem.text = `$(watch) MoonCode Login`;
+  statusBarItem.backgroundColor = new ThemeColor(
+    "statusBarItem.warningBackground",
+  );
   statusBarItem.command = "MoonCode.login";
   statusBarItem.tooltip =
-    "MoonCode: You are actually logged out. Click to login";
+    "MoonCode: You are currently logged out. Click to login";
 };


### PR DESCRIPTION
## Commits

- [fix: status bar](https://github.com/Friedrich482/mooncode/commit/b6a998ffaf72e622458c88e6c1da67e1f723e16b)
	- added a warning background color to the status bar when the user is logged out to drag his attention and remember him that he has to log in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated status bar tooltip text for clarity when logged out.

* **New Features**
  * Status bar now displays theme-aware background colors based on context—active when showing time spent and warning when displaying the logged-out prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->