### PR TITLE
Matrix build for api and web apps ci/cd

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -5,12 +5,11 @@ on:
     branches: "main"
 
 jobs:
-  build-and-push-docker-images:
+  setup:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup nodejs
         uses: actions/setup-node@v6
@@ -19,19 +18,48 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint project
         run: npm run lint
 
+  build:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix:
+        include:
+          - app: api
+            image: mooncode-api
+            dockerfile: apps/api/Dockerfile
+
+          - app: web
+            image: mooncode-web
+            dockerfile: apps/web/Dockerfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images
-        run: |
-          IMAGE_TAG=${{ github.sha }}
-          docker buildx build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_USERNAME }}/mooncode-api:$IMAGE_TAG -t ${{ secrets.DOCKERHUB_USERNAME }}/mooncode-api:latest --push -f apps/api/Dockerfile .
-          docker buildx build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_USERNAME }}/mooncode-web:$IMAGE_TAG -t ${{ secrets.DOCKERHUB_USERNAME }}/mooncode-web:latest --push -f apps/web/Dockerfile .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push ${{ matrix.app }}
+        uses: docker/build-push-action@v7
+        env:
+          BUILDKIT_PROGRESS: plain
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+          cache-from: type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}


### PR DESCRIPTION
## Commits

- [ci: web and api](https://github.com/Friedrich482/mooncode/commit/ff3a0bfc7ac834ef1a9ee801e25371296b527943)
	- updated the ci/cd pipeline responsible of the web and api apps to use a matrix build