### PR TITLE
ci: internal package

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -24,6 +24,11 @@ jobs:
       - name: Lint project
         run: npm run lint
 
+      # This step is necessary because @repo/common is a compiled package of the monorepo (https://turborepo.dev/docs/core-concepts/internal-packages#compiled-packages)
+      # That package needs to be compiled in order to be consumed by the apps for the testing step
+      - name: Build @repo/common package
+        run: npm run build -w @repo/common
+
       - name: Test project
         run: npm run test
 


### PR DESCRIPTION
- added a step in the setup job of the `build-and-deploy` ci/cd pipeline to build the @repo/common internal package first before running the tests because that package is a compiled package that needs to be consumed by the apps during the test step