### PR TITLE
ci: vitest

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
     "migrate": "npx drizzle-kit migrate",
     "studio": "drizzle-kit studio",
     "lint": "eslint \"**/*.{ts,tsx}\" --fix",
-    "test": "vitest",
+    "test": "vitest run --browser.headless",
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui --coverage",
     "test:debug": "vitest --inspect-brk --inspect --logHeapUsage --threads=false",


### PR DESCRIPTION
- made vitest browser run in headless mode for ci/cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the API test command to run in headless browser mode with an explicit test run, aligning test execution with the new workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->