### PR TITLE
ci: vscode extension

### DIFF
--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -3,6 +3,10 @@ name: MoonCode Extension CI/CD Pipeline - Bump and publish extension version
 on:
   push:
     branches: "main"
+    paths:
+      - apps/dashboard/**
+      - apps/vscode-extension/**
+      - packages/common/**
 
 jobs:
   build-and-publish:

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "mooncode",
   "displayName": "MoonCode",
   "description": "MoonCode is an extension that tracks your coding time (like WakaTime) and gives you a detailed summary about all your coding statistics. With MoonCode, developers get the full history of their coding activity.",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "icon": "./public/moon.png",
   "publisher": "Friedrich482",
   "author": {


### PR DESCRIPTION
- added a filter to run the ci script of the vscode extension version bump and publishing only if the files of the extension itself, dashboard or packages/common change