### PR TITLE
Headless browser in CI

### DIFF
--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -32,7 +32,7 @@ jobs:
           npm run publish:patch --workspace=mooncode
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          VITE_API_URL: ${{secrets.VITE_API_URL}}
-          VITE_LOGOUT_URL: ${{secrets.VITE_LOGOUT_URL}}
-          VITE_AUTH_GOOGLE_URL: ${{secrets.VITE_AUTH_GOOGLE_URL}}
-          VITE_LINKING_GOOGLE_ACCOUNT_URL: ${{secrets.VITE_LINKING_GOOGLE_ACCOUNT_URL}}
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_LOGOUT_URL: ${{ secrets.VITE_LOGOUT_URL }}
+          VITE_AUTH_GOOGLE_URL: ${{ secrets.VITE_AUTH_GOOGLE_URL }}
+          VITE_LINKING_GOOGLE_ACCOUNT_URL: ${{ secrets.VITE_LINKING_GOOGLE_ACCOUNT_URL }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
     "migrate": "npx drizzle-kit migrate",
     "studio": "drizzle-kit studio",
     "lint": "eslint \"**/*.{ts,tsx}\" --fix",
-    "test": "vitest run --browser.headless",
+    "test": "vitest",
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui --coverage",
     "test:debug": "vitest --inspect-brk --inspect --logHeapUsage --threads=false",

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
           include: ["./src/email/utils/*.test.tsx"],
           browser: {
             enabled: true,
+            headless: process.env.CI === "true",
             provider: playwright(),
             instances: [{ browser: "chromium" }],
           },


### PR DESCRIPTION
## Commits

- [chore: actions version](https://github.com/Friedrich482/mooncode/commit/7bab7e69f088e204201b0f043b76764da04211c4)
	- bumped the version of the checkout action to `v6` in the extension bump and publish ci script

- [ci: headless browser](https://github.com/Friedrich482/mooncode/commit/8280cc9104984020c0e857e114902a0fb180c9dd)
	- in ci mode the playwright browser is used in headless mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use the latest checkout action and standardized environment variable formatting.
  * Adjusted test execution so it runs more consistently across local and CI environments.
* **Bug Fixes**
  * Improved browser test behavior to run headless only in CI, reducing unexpected test issues during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->